### PR TITLE
feat: add filter for courses inside institutions

### DIFF
--- a/course_classification/templates/course_classification/institution.html
+++ b/course_classification/templates/course_classification/institution.html
@@ -55,9 +55,11 @@
         <section class="highlighted-courses" style="padding-top: 25px;">
             <ul class="courses-list">
                 %for course in courses:
-                    <li class="mb-3">
-                        <%include file="../course.html" args="course=course, main_class={}" />
-                    </li>
+                    %if course.catalog_visibility == 'both':
+                        <li class="mb-3">
+                            <%include file="../course.html" args="course=course, main_class={}" />
+                        </li>
+                    %endif
                 %endfor
             </ul>
         </section>


### PR DESCRIPTION
- Courses with `catalog_visibility` set to "about" or "none" in advanced settings are excluded from this institutional catalog display.