### PR TITLE
Cata ilabaca/add initial setting and fixes

### DIFF
--- a/course_classification/api.py
+++ b/course_classification/api.py
@@ -2,8 +2,10 @@
 # Python Standard Libraries
 import datetime
 import logging
+from dateutil.relativedelta import relativedelta
 
 # Installed packages (via pip)
+from django.conf import settings
 from django.db.models import Q
 from search.api import *
 
@@ -38,8 +40,13 @@ def course_discovery_search_eol(search_term=None, size=200, from_=0, order_by=""
         sort = "start:desc"
     if order_by == "older":
         sort = "start"
+    today = datetime.utcnow()
+    start_initial_year = int(configuration_helpers.get_value('COURSE_SEARCH_INITIAL_YEAR',getattr(settings, 'COURSE_SEARCH_INITIAL_YEAR', 2020)))
+    time_horizon = int(configuration_helpers.get_value('COURSE_SEARCH_FUTURE_TIME_HORIZON',getattr(settings, 'COURSE_SEARCH_FUTURE_TIME_HORIZON', 262080)))
+    future_end_year = today + relativedelta(minutes=+time_horizon)
+    possible_years = list(range(start_initial_year, future_end_year.year + 1))
     # Check if year exist and test if is it numeric
-    if year != "" and year.isnumeric():
+    if year != "" and year.isnumeric() and year in possible_years:
         year_int = int(year)
         # Check if the start date range between January 1 and December 31 of a year
         query &= Q(start__range = (datetime(year_int, 1, 1), datetime(year_int, 12, 31)))

--- a/course_classification/settings/common.py
+++ b/course_classification/settings/common.py
@@ -2,5 +2,5 @@ def plugin_settings(settings):
     settings.EXPLORE_COURSES_PAGE_SIZE = 20
     settings.MAX_ELASTICSEARCH_PAGE_SIZE = 200
     settings.COURSE_SEARCH_INITIAL_YEAR = 2020
-    settings.COURSE_SEARCH_FUTURE_TIME_HORIZON = 262080
+    settings.COURSE_SEARCH_FUTURE_TIME_HORIZON = 262080 #approx 6 month
     

--- a/course_classification/settings/common.py
+++ b/course_classification/settings/common.py
@@ -1,2 +1,6 @@
 def plugin_settings(settings):
-    pass
+    settings.EXPLORE_COURSES_PAGE_SIZE = 20
+    settings.MAX_ELASTICSEARCH_PAGE_SIZE = 200
+    settings.COURSE_SEARCH_INITIAL_YEAR = 2020
+    settings.COURSE_SEARCH_FUTURE_TIME_HORIZON = 262080
+    

--- a/course_classification/urls.py
+++ b/course_classification/urls.py
@@ -2,7 +2,7 @@
 from django.conf.urls import url
 
 # Internal project dependencies
-from .views import CourseClassificationView, course_discovery_eol, get_course_categories_view, get_main_classifications_view
+from .views import CourseClassificationView, course_discovery_eol, get_course_categories_view, get_main_classifications_view, get_initial_settings
 
 
 urlpatterns = (
@@ -14,4 +14,5 @@ urlpatterns = (
     url(r'^course_classification/search/$', course_discovery_eol, name='course_discovery_eol'),
     url(r'^course_classification/get_main_classifications/', get_main_classifications_view, name='get_all_main_classifications'),
     url(r'^course_classification/get_course_categories/', get_course_categories_view, name='get_all_course_categories'),
+    url(r'^course_classification/get_initial_settings/', get_initial_settings, name='get_initial_date_settings'),
 )

--- a/course_classification/views.py
+++ b/course_classification/views.py
@@ -6,6 +6,7 @@ import json
 import logging
 
 # Installed packages (via pip)
+from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.test.client import RequestFactory
@@ -207,4 +208,14 @@ def get_course_categories_view(request):
     """
     categories = get_all_course_categories()
     data = [{'id': c[0], 'name': c[1]} for c in categories]
+    return JsonResponse(data)
+
+@require_GET
+def get_initial_settings(request):
+    """
+        View to obtain initial date data
+    """
+    initial_year = int(configuration_helpers.get_value('COURSE_SEARCH_INITIAL_YEAR',getattr(settings, 'COURSE_SEARCH_INITIAL_YEAR', 2020)))
+    time_horizon = int(configuration_helpers.get_value('COURSE_SEARCH_FUTURE_TIME_HORIZON',getattr(settings, 'COURSE_SEARCH_FUTURE_TIME_HORIZON', 262080)))
+    data = {'initial_year': initial_year, 'time_horizon': time_horizon} 
     return JsonResponse(data)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="course_classification",
-    version="1.5.2",
+    version="1.6.0",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description=".",


### PR DESCRIPTION
Se agregan settings nuevas para el año de inicio y tiempo en el futuro para el calculo de años
Se agrega un nuevo endpoint para obtener los valores iniciales del año inicial y el tiempo extra para utilizarlas en el front